### PR TITLE
add support for 1-on-1s

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,21 +1,24 @@
 import discord
 import dotenv
+import random
+from datetime import datetime, timedelta
 import os
 import asyncio
-
+import json
+from pairing import PairingAlgorithm
 
 dotenv.load_dotenv()
 
-TOKEN = os.environ['DISCORD_BOT_TOKEN']
-GUILD_ID = os.environ['GUILD_ID']
-THREAD_ONLY_CATEGORY_ID = int(os.environ['THREAD_ONLY_CATEGORY_ID'])
+TOKEN = os.environ["DISCORD_BOT_TOKEN"]
+GUILD_ID = os.environ["GUILD_ID"]
+THREAD_ONLY_CATEGORY_ID = int(os.environ["THREAD_ONLY_CATEGORY_ID"])
 
 bot = discord.Bot(intents=discord.Intents.all())
 
 
 @bot.event
 async def on_ready():
-    print(f'We have logged in as {bot.user}')
+    print(f"We have logged in as {bot.user}")
 
 
 @bot.event
@@ -23,9 +26,9 @@ async def on_message(message: discord.Message):
     if message.author == bot.user:
         return
 
-    print(f'[{message.author}]: {message.content}')
-    if message.content.startswith('.hello'):
-        await message.channel.send('Hello!')
+    print(f"[{message.author}]: {message.content}")
+    if message.content.startswith(".hello"):
+        await message.channel.send("Hello!")
 
     # create a thread if it's a thread only channel!
     if isinstance(message.channel, discord.TextChannel):
@@ -37,11 +40,139 @@ async def on_message(message: discord.Message):
             await thread.send(f"Thread created (thread only channel)")
 
 
-
 @bot.slash_command(guild_ids=[GUILD_ID])
 async def hello(ctx):
     await ctx.respond("Hello!")
 
 
+@bot.slash_command(guild_ids=[GUILD_ID])
+async def add_1_on_1(ctx: discord.Interaction):
+    # add 1on1 role to user
+    role = discord.utils.get(ctx.guild.roles, name="1on1")
+    await ctx.author.add_roles(role)
+    await ctx.respond("You have signed up for 1on1s!")
 
+
+@bot.slash_command(guild_ids=[GUILD_ID])
+async def remove_1_on_1(ctx):
+    # remove 1on1 role from user
+    role = discord.utils.get(ctx.guild.roles, name="1on1")
+    await ctx.author.remove_roles(role)
+    await ctx.respond("You have removed yourself from 1on1s!")
+
+
+@bot.slash_command(guild_ids=[GUILD_ID])
+async def show_1on1_signed_up(ctx):
+    # show all users with 1on1 role
+    role = discord.utils.get(ctx.guild.roles, name="1on1")
+    users = [member.name for member in ctx.guild.members if role in member.roles]
+    await ctx.respond(f"Users with 1on1 role: {', '.join(users)}")
+
+
+async def pair_for_1on1s(guild):
+    role = discord.utils.get(guild.roles, name="1on1")
+    users = [member.id for member in guild.members if role in member.roles]
+    algorithm = PairingAlgorithm(users)
+    # get the last message from "1on1-history" and load it into history
+    channel = discord.utils.get(guild.channels, name="1on1-history")
+    last_message = channel.last_message
+    if last_message:
+        algorithm.load_history(last_message.content)
+    else:
+        algorithm.load_history("{}")
+    # find all the users with role 1on1filler and pick a random one
+    filler_role = discord.utils.get(guild.roles, name="1on1filler")
+    filler_id = [member.id for member in guild.members if filler_role in member.roles]
+    random.shuffle(filler_id)
+    filler_id = filler_id[0] if filler_id else None
+    pairs = algorithm.pair_people(filler=filler_id)
+    h = algorithm.serialize_history()
+    # save the serialized history into a message to load later
+    channel = discord.utils.get(guild.channels, name="1on1-history")
+    await channel.send(h)
+    # save the pairs into "1on1-pairs"
+    channel = discord.utils.get(guild.channels, name="1on1-pairs")
+    await channel.send(json.dumps(pairs))
+    return pairs
+
+def mention_(user, safe=False):
+    mention = user.mention
+    if safe:
+        # just return @ and then the user's nick
+        return f"@{user.display_name}"
+    else:
+        return user.mention
+
+
+async def display_pairs(guild, pairs, user_asked=None, ctx=None, channel=None):
+    if ctx and channel:
+        raise ValueError("Only one of 'ctx' and 'channel' should be provided, not both.")
+    if not ctx and not channel:
+        raise ValueError("Either 'ctx' or 'channel' must be provided.")
+    # for each pair, get the user from their discriminator and mention them
+    users = []
+    for pair in pairs:
+        user1 = discord.utils.get(guild.members, id=pair[0])
+        user2 = discord.utils.get(guild.members, id=pair[1])
+        if user_asked:
+            # basically, we don't want to mention users if only a single user asked what the pairs were
+            if user_asked == pair[0]:
+                users.append(f"{mention_(user1)} — {mention_(user2, safe=True)}")
+            elif user_asked == pair[1]:
+                users.append(f"{mention_(user1, safe=True)} — {mention_(user2)}")
+            else:
+                users.append(f"{mention_(user1, safe=True)} — {mention_(user2, safe=True)}")
+        else:
+            users.append(f"{mention_(user1)} — {mention_(user2)}")
+        
+    if ctx:
+        await ctx.respond(f"1on1 pairs: {', '.join(users)}")
+    elif channel:
+        await channel.send(f"1on1 pairs: {', '.join(users)}")
+
+
+@bot.slash_command(guild_ids=[GUILD_ID])
+async def pair_1on1s(ctx):
+    # require admin
+    if not ctx.author.guild_permissions.administrator:
+        await ctx.respond("You must be an admin to run this command.")
+        return
+    pairs = await pair_for_1on1s(ctx.guild)
+    await display_pairs(ctx.guild, pairs, ctx=ctx)
+
+
+@bot.slash_command(guild_ids=[GUILD_ID])
+async def show_1on1_pairs(ctx):
+    channel = discord.utils.get(ctx.guild.channels, name="1on1-pairs")
+    last_message = channel.last_message
+    if last_message:
+        pairs_json = last_message.content
+        pairs = json.loads(pairs_json)
+        await display_pairs(ctx.guild, pairs, user_asked=ctx.author.id, ctx=ctx)
+    else:
+        await ctx.respond("No pairs found")
+def next_sunday():
+    now = datetime.now()
+    days_until_sunday = (6 - now.weekday()) % 7  # 6 represents Saturday, so this gives us Sunday
+    if days_until_sunday == 0 and now.hour >= 9:  # If today is Sunday and it's past 9 AM
+        days_until_sunday = 7  # Wait until next Sunday
+    next_sunday = now + timedelta(days=days_until_sunday)
+    r = next_sunday.replace(hour=7, minute=00, second=0, microsecond=0)
+    print(f"running pairs in {r}")
+    return r
+async def weekly_task():
+    await bot.wait_until_ready()  # Wait until the bot has finished logging in
+    for guild in bot.guilds:
+        while not bot.is_closed():
+            next_run = next_sunday()  # Get the next Sunday at 9 AM
+            await asyncio.sleep((next_run - datetime.now()).total_seconds())  # Sleep until it's time for the next run
+            # get the last message in 1-1s and then get a context from that
+            pairs = await pair_for_1on1s(guild)
+            # get the 1-1s channel
+            channel = discord.utils.get(guild.channels, name="1-1s")
+            await display_pairs(guild, pairs, channel=channel)
+
+
+
+bot.loop.create_task(weekly_task())
 bot.run(TOKEN)

--- a/pairing.py
+++ b/pairing.py
@@ -1,0 +1,85 @@
+import json
+import random
+from collections import defaultdict
+
+
+class PairingAlgorithm:
+    def __init__(self, people):
+        self.people = people
+        self.history = self.initialize_history()
+
+    def initialize_history(self):
+        """Initialize the history of pairings as a dictionary of sets."""
+        history = defaultdict(set)
+        for person in self.people:
+            history[person] = set()
+        return history
+
+    def find_possible_pairs(self, used):
+        """Generate pairs that are least frequent based on history, excluding already used people."""
+        min_pairs = []
+        min_count = float("inf")
+
+        # Check all combinations for the least frequent pairs
+        for i in range(len(self.people)):
+            if self.people[i] in used:
+                continue
+            for j in range(i + 1, len(self.people)):
+                if self.people[j] in used:
+                    continue
+                pair = (self.people[i], self.people[j])
+                occurrences = len(
+                    self.history[self.people[i]].intersection(
+                        self.history[self.people[j]]
+                    )
+                )
+                if occurrences < min_count:
+                    min_pairs = [pair]
+                    min_count = occurrences
+                elif occurrences == min_count:
+                    min_pairs.append(pair)
+
+        return min_pairs
+
+    def update_history(self, pair):
+        """Update the history with the new pair."""
+        person1, person2 = pair
+        self.history[person1].add(person2)
+        self.history[person2].add(person1)
+
+    def pair_people(self, filler=None):
+        """Pair people by updating history and selecting least frequent pairs."""
+        random.shuffle(self.people)  # Randomize order to ensure variety
+        pairs = []
+        # if we have an odd number and a filler id, take the last person and match them with the filler
+        if len(self.people) % 2 == 1:
+            if filler:
+                if self.people[-1] == filler:
+                    pairs.append((self.people[-2], filler))
+                    self.people.remove(self.people[-2])
+                else:
+                    pairs.append((self.people.pop(), filler))
+        used = set()
+
+        while len(used) < len(self.people):
+            possible_pairs = self.find_possible_pairs(used)
+            if possible_pairs:
+                pair = random.choice(possible_pairs)
+                pairs.append(pair)
+                self.update_history(pair)
+                used.update(pair)
+            else:
+                break
+
+        return pairs
+
+    def serialize_history(self):
+        """Serialize the history into JSON format, converting sets to lists."""
+        return json.dumps({k: list(v) for k, v in self.history.items()})
+
+    def load_history(self, json_history):
+        """Load history from JSON format, converting lists back to sets."""
+        self.history = defaultdict(
+            set, {k: set(v) for k, v in json.loads(json_history).items()}
+        )
+


### PR DESCRIPTION
Sorry for changing the formatting, but I (my editor automatically) used black which is the canonical formatter, so it should be more consistent in the future.

This uses 2 auxiliary channels:
1on1-pairs (stores the current pairing) and 1on1-history (stores json blobs of who has been paired with who), so you should create these and make sure that the bot can read and write from them.

This uses 2 roles: 1on1 role to manage who has 1on1s. So the bot should have a higher role than this.
1on1filler to pick users to be matched twice if there is an odd number. It picks randomly from these. So add this role also and assign it to people who are willing.

Adds the following commands:
`/add_1_on_1`: adds the user to 1on1s
`/remove_1_on_1`: removes the user to 1on1s
`/pair_1on1s`: manually do pairing, requires admin
`/show_1on1_pairs`: this displays the pairings to a user, only pinging the user who asked

By default, it runs the pairings and pings everyone involved at 7am every Sunday (time zone is just time zone of the server). This is easy to customize.

It uses a kind of heuristic algorithm to try to avoid duplicates, and this should work much better the more people sign up. I've only tested this with 4 users and it seems to work.